### PR TITLE
 Specify Dart SDK >2.0.0 in pubspec.yaml

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,8 +1,11 @@
 name: dbutils
 description: Database Utilities Library
-version: 0.0.1
+version: 0.0.2
 author:
 homepage:
+
+environment:
+  sdk: ">=2.0.0 <3.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
This PR allows building this package against whatever version is the latest Dart SDK .